### PR TITLE
HTTPS-ify All Links

### DIFF
--- a/_includes/_front/aside.html
+++ b/_includes/_front/aside.html
@@ -2,7 +2,7 @@
       <div class="container text-center">
           <div class="call-to-action">
               <h2>Check out our blog! We write stuff there.</h2>
-              <a href="http://blog.sotonsailrobot.org" class="btn btn-default btn-xl wow tada">Visit Blog</a>
+              <a href="https://blog.sotonsailrobot.org" class="btn btn-default btn-xl wow tada">Visit Blog</a>
           </div>
       </div>
   </aside>

--- a/_includes/_front/sponsors.html
+++ b/_includes/_front/sponsors.html
@@ -8,13 +8,13 @@
     </div>
     <div class="row">
       <div class="col-md-12 text-center">
-        <a href="http://www.southampton.ac.uk/iliad/education-innov/eef.page?page=1">Education Enhancement Fund - University of Southampton</a>,
+        <a href="https://www.southampton.ac.uk/iliad/education-innov/eef.page?page=1">Education Enhancement Fund - University of Southampton</a>,
         <a href="https://www.southampton.ac.uk/engineering/research/groups/fsi.page">Fluid Structure Interactions Group</a>,
         <a href="https://noc.ac.uk">MARS Group - National Oceanography Centre</a>,
         Lester Gilbert,
         <a href="https://www.xsens.com">Xsens</a>,
-        <a href="http://www.sailsetc2.com/store/">SailsEtc</a>,
-        Nigel Brown, <a href="http://www.catsails.co.uk/">Catsails</a>,
+        <a href="https://www.sailsetc2.com/store/">SailsEtc</a>,
+        Nigel Brown, <a href="https://www.catsails.co.uk/">Catsails</a>,
         Alistair Lynn,
         Tim Miller,
         Tobias Schneider,

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,7 +1,7 @@
 <head>
 
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta https-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="">
     <meta name="author" content="">
@@ -12,8 +12,8 @@
     <link rel="stylesheet" href="css/bootstrap.min.css" type="text/css">
 
     <!-- Custom Fonts -->
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Merriweather:400,300,300italic,400italic,700,700italic,900,900italic' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Merriweather:400,300,300italic,400italic,700,700italic,900,900italic' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="font-awesome/css/font-awesome.min.css" type="text/css">
 
     <!-- Plugin CSS -->


### PR DESCRIPTION
Closes: #15 

Adds the Golden S in all HTTP links that we have in our content. I have clicked on all links and they do lead to the right places, save for two things:
* The blog site is no more :( The domain's expired probably?
* The link to the Education Enhancement Fund redirects to [this page now](https://www.southampton.ac.uk/professional-development/index.page), even though [this other page](https://www.southampton.ac.uk/professional-development/teaching-and-learning/education-innov/index.page) still has a thumbnail that should link to info about the fund.